### PR TITLE
Fix GitHub Edit URL for the default index page

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -60,8 +60,12 @@ const navigation = {
   ],
 };
 
-const pathToPermalink = (path: string) =>
-  `https://github.com/buttondown-email/docs/blob/main/pages${path}.mdx`;
+const pathToPermalink = (path: string) => {
+  if (path === '/') {
+    path = '/index';
+  }
+  return `https://github.com/buttondown-email/docs/blob/main/pages${path}.mdx`;
+}
 
 export default function Footer() {
   const { asPath, pathname } = useRouter();


### PR DESCRIPTION
The default index page from `useRouter` is `/` so the final URL created ends up looking like `https://github.com/buttondown-email/docs/blob/main/pages/.mdx` but should be like `https://github.com/buttondown-email/docs/blob/main/pages/index.mdx`. This is fixed.

Fixes #30