### PR TITLE
Remove attempted link-inside-inline-code element.

### DIFF
--- a/pages/getting-started/hosting-on-a-custom-domain.mdx
+++ b/pages/getting-started/hosting-on-a-custom-domain.mdx
@@ -40,7 +40,7 @@ This isn't possible to do in the UI, but there are no technical limitations. [Em
 
 ## The difference between hosting domains and sending domains
 
-**Hosting on a custom domain** means using a domain outside of `[buttondown.email](http://buttondown.email)` to host your newsletter and archives — for example, [newsletter.jmduke.com](http://newsletter.jmduke.com).
+**Hosting on a custom domain** means using a domain outside of `buttondown.email` to host your newsletter and archives — for example, [newsletter.jmduke.com](http://newsletter.jmduke.com).
 
 **Sending from a custom domain** means setting up your DNS records so that Buttondown sends outgoing emails from your domain, improving reputation and delivery metrics.
 


### PR DESCRIPTION
It was rendering as a literal `[foo](foo)` instead of as a link: https://docs.buttondown.email/getting-started/hosting-on-a-custom-domain#the-difference-between-hosting-domains-and-sending-domains