### PR TITLE
Clarification for custom domains

### DIFF
--- a/pages/getting-started/hosting-on-a-custom-domain.mdx
+++ b/pages/getting-started/hosting-on-a-custom-domain.mdx
@@ -28,11 +28,15 @@ setting up a custom domain on which to host it makes a lot of sense.
 ## Setting up your custom hosting domain
 
 1. If you're not signed up for either the **Standard** or **Professional** plan, go ahead and [upgrade your account](https://buttondown.email/settings)!
-2. Add the custom domain in your [settings page](https://buttondown.email/settings).
+2. Add a custom email under `Email address`, set to `youremail@customdomain.com.`
+3. Add the custom domain in your [settings page](https://buttondown.email/settings).
 
 ![A screenshot of the custom domain modal.](/images/custom-domain.png)
 
-3. Change the `CNAME` record of the domain you'd like to use as your custom domain to `buttondown.email`. The prompt should walk you through the rest of the process?
+Note that the hosting domain should be a custom subdomain, such as `[newsletter.janedoe.com](http://newsletter.janedoe.com)`, and that
+the sending domain should be `domain.com`. The sending domain should match the custom email you have set.  
+
+4. Once you have changed the hosting domain, the text box will prompt you to change the `CNAME` record of the domain you'd like to use as your custom domain and provide you with a CNAME that ends with `herokudns.com` that you'll need to change with your DNS provider.   
 
 ## Using a subdomain of `buttondown.email`
 


### PR DESCRIPTION
Adding clarification around the custom sending domain - it should just be [janedoe.com](http://janedoe.com/) (in my case at least), mail doesn't work if you're using a custom email address since you then need it to be [email@mail.janedoe.com](mailto:email@mail.janedoe.com).


<img width="947" alt="Screenshot 2023-12-27 at 9 40 33 AM" src="https://github.com/buttondown-email/docs/assets/3837836/6155b055-3549-43d5-a538-7fb516fa516d">
